### PR TITLE
Fix MessageDefNode and OneofDeclNode field types

### DIFF
--- a/src/Ast/MessageDefNode.php
+++ b/src/Ast/MessageDefNode.php
@@ -11,7 +11,7 @@ final readonly class MessageDefNode implements NodeInterface
     public function __construct(
         /** @var non-empty-string */
         public string $name,
-        /** @var FieldDeclNode[]|OneofDeclNode[]|ReservedNode[] */
+        /** @var FieldDeclNode[]|OneofDeclNode[]|MapFieldDeclNode|ReservedNode[] */
         public array $fields = [],
         /** @var MessageDefNode */
         public array $messages = [],

--- a/src/Ast/OneofDeclNode.php
+++ b/src/Ast/OneofDeclNode.php
@@ -10,7 +10,7 @@ final readonly class OneofDeclNode implements NodeInterface
 {
     public function __construct(
         public string $name,
-        /** @var FieldDeclNode[] */
+        /** @var OneofFieldNode[] */
         public array $fields = [],
         /** @var OptionDeclNode[] */
         public array $options = [],


### PR DESCRIPTION
Corrected type annotations for fields in MessageDefNode to properly represent the structure of Protocol Buffer messages in the AST.